### PR TITLE
Fixing squid:S1118 -   Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/hantsylabs/restexample/springmvc/ApiErrors.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/ApiErrors.java
@@ -5,10 +5,13 @@ package com.hantsylabs.restexample.springmvc;
  *
  * @author Hantsy Bai<hantsy@gmail.com>
  */
-public class ApiErrors {
-
+public final class ApiErrors {
+	
     private static final String PREFIX = "errors.";
 
     public static final String INVALID_REQUEST = PREFIX + "INVALID_REQUEST";
-
+    
+    private ApiErrors() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
 }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/Constants.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/Constants.java
@@ -1,6 +1,6 @@
 package com.hantsylabs.restexample.springmvc;
 
-public class Constants {
+public final class Constants {
 
     /**
      * prefix of REST API
@@ -10,5 +10,9 @@ public class Constants {
     public static final String URI_POSTS = "/posts";
 
     public static final String URI_COMMENTS = "/comments";
+    
+    private Constants() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
     
 }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/DTOUtils.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/DTOUtils.java
@@ -12,9 +12,13 @@ import org.springframework.data.domain.PageRequest;
  *
  * @author Hantsy Bai<hantsy@gmail.com>
  */
-public class DTOUtils {
+public final class DTOUtils {
 
     private static final ModelMapper INSTANCE = new ModelMapper();
+    
+    private DTOUtils() {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static <S, T> T map(S source, Class<T> targetClass) {
         return INSTANCE.map(source, targetClass);

--- a/src/main/java/com/hantsylabs/restexample/springmvc/repository/PostSpecifications.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/repository/PostSpecifications.java
@@ -16,7 +16,11 @@ import org.springframework.util.StringUtils;
  * @author Hantsy Bai<hantsy@gmail.com>
  *
  */
-public class PostSpecifications {
+public final class PostSpecifications {
+	
+	private PostSpecifications() {
+	      throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     public static Specification<Post> filterByKeywordAndStatus(
             final String keyword,//

--- a/src/test/java/com/hantsylabs/restexample/springmvc/test/Fixtures.java
+++ b/src/test/java/com/hantsylabs/restexample/springmvc/test/Fixtures.java
@@ -7,7 +7,11 @@ import com.hantsylabs.restexample.springmvc.model.PostForm;
  *
  * @author hantsy
  */
-public class Fixtures {
+public final class Fixtures {
+	
+	private Fixtures() {
+	      throw new InstantiationError( "Must not instantiate this class" );
+	}
 
     public static Post createPost(String title, String content) {
         Post post = new Post();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1118 - Utility classes should not have public constructors". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Sameer Misger
