### PR TITLE
Fixing squid:S1488, Fixingsquid:S1611, Fixing squid:S1213

### DIFF
--- a/src/main/java/com/hantsylabs/restexample/springmvc/api/RestExceptionHandler.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/api/RestExceptionHandler.java
@@ -66,7 +66,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         List<FieldError> fieldErrors = result.getFieldErrors();
 
         if (!fieldErrors.isEmpty()) {
-            fieldErrors.stream().forEach((e) -> {
+            fieldErrors.stream().forEach(e -> {
                 alert.addError(e.getField(), e.getCode(), e.getDefaultMessage());
             });
         }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/config/SecurityConfig.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/config/SecurityConfig.java
@@ -79,8 +79,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	public PlaintextPasswordEncoder passwordEncoder() {
-		PlaintextPasswordEncoder passwordEncoder = new PlaintextPasswordEncoder();
-		return passwordEncoder;
+		return new PlaintextPasswordEncoder();
 	}
 
 }

--- a/src/main/java/com/hantsylabs/restexample/springmvc/model/ResponseMessage.java
+++ b/src/main/java/com/hantsylabs/restexample/springmvc/model/ResponseMessage.java
@@ -17,6 +17,8 @@ public class ResponseMessage {
     private Type type;
     private String text;
     private String code;
+    
+    private List<Error> errors = new ArrayList<Error>();
 
     public ResponseMessage(Type type, String text) {
         this.type = type;
@@ -57,7 +59,6 @@ public class ResponseMessage {
         return new ResponseMessage(Type.info, text);
     }
 
-    private List<Error> errors = new ArrayList<Error>();
 
     public List<Error> getErrors() {
         return errors;

--- a/src/test/java/com/hantsylabs/restexample/springmvc/test/MockDataConfig.java
+++ b/src/test/java/com/hantsylabs/restexample/springmvc/test/MockDataConfig.java
@@ -46,8 +46,7 @@ public class MockDataConfig {
 
     @Bean
     public CommentRepository commentRepository() {
-        CommentRepository commentRepository = mock(CommentRepository.class);
-        return commentRepository;
+        return mock(CommentRepository.class);
     }
     
     @Bean


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1488 - Local Variables should not be declared and then immediately returned or thrown, squid:S1611 - Parentheses should be removed from a single lambda input parameter when its type is inferred, squid:S1213-The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1611 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1213 

Please let me know if you have any questions.
Sameer Misger
